### PR TITLE
make api for board - 구현까지 완료

### DIFF
--- a/spring-board/.gitignore
+++ b/spring-board/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,macos,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=java,gradle,intellij+all,windows,macos,visualstudiocode
 
+### Querydsl
+/src/main/generated
+
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/spring-board/build.gradle
+++ b/spring-board/build.gradle
@@ -32,9 +32,33 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-
+    // queryDSL 설정
+    implementation "com.querydsl:querydsl-jpa"
+    implementation "com.querydsl:querydsl-core"
+    implementation "com.querydsl:querydsl-collections"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa" // querydsl JPAAnnotationProcessor 사용 지정
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 대응 코드
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api" // java.lang.NoClassDefFoundError (javax.annotation.Entity) 대응 코드
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }

--- a/spring-board/src/main/java/com/springboard/springboard/repository/ArticleCommentRepository.java
+++ b/spring-board/src/main/java/com/springboard/springboard/repository/ArticleCommentRepository.java
@@ -1,9 +1,27 @@
 package com.springboard.springboard.repository;
 
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.springboard.springboard.domain.ArticleComment;
+import com.springboard.springboard.domain.QArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
-public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
+public interface ArticleCommentRepository extends
+        JpaRepository<ArticleComment, Long>,
+        QuerydslPredicateExecutor<ArticleComment>,
+        QuerydslBinderCustomizer<QArticleComment>
+{
+    @Override
+    default void customize(QuerydslBindings bindings, QArticleComment root){
+        bindings.including( root.content,  root.createdAt, root.createdBy);
+        bindings.bind(root.content).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.createdAt).first(DateTimeExpression::eq);
+        bindings.bind(root.createdBy).first(StringExpression::containsIgnoreCase);
+
+    }
 }

--- a/spring-board/src/main/java/com/springboard/springboard/repository/ArticleRepository.java
+++ b/spring-board/src/main/java/com/springboard/springboard/repository/ArticleRepository.java
@@ -1,9 +1,31 @@
 package com.springboard.springboard.repository;
 
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.springboard.springboard.domain.Article;
+import com.springboard.springboard.domain.QArticle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
-public interface ArticleRepository extends JpaRepository<Article, Long> {
+public interface ArticleRepository extends
+        JpaRepository<Article, Long>,
+        QuerydslPredicateExecutor<Article>,
+        QuerydslBinderCustomizer<QArticle>
+{
+    @Override
+    default void customize(QuerydslBindings bindings, QArticle root){
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.title, root.content, root.hashtag, root.createdAt, root.createdBy);
+        bindings.bind(root.title).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.content).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.hashtag).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.createdAt).first(DateTimeExpression::eq);
+        bindings.bind(root.createdBy).first(StringExpression::containsIgnoreCase);
+
+    }
 }

--- a/spring-board/src/test/java/com/springboard/springboard/controller/DataRestTest.java
+++ b/spring-board/src/test/java/com/springboard/springboard/controller/DataRestTest.java
@@ -1,5 +1,6 @@
 package com.springboard.springboard.controller;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Disabled("Spring Data REST 통합테스트는 불필요하므로 제외시킴")
 @DisplayName("Data Rest - API 테스트")
 @Transactional
 @AutoConfigureMockMvc


### PR DESCRIPTION
Querydsl 적용
Repository에  
QuerydslPredicateExecutor
QuerydslBinderCustomizer 상속하고,
customize(QuerydslBindings bindings, QArticleComment root) 오버라이딩하여 검색필드 추가 및 like % 기능구현

This closes #1